### PR TITLE
Add separate annotation `Bitmask` for bitmask types, distinguishing from `EnumType`.

### DIFF
--- a/modules/ffm-plus/pom.xml
+++ b/modules/ffm-plus/pom.xml
@@ -40,7 +40,7 @@
     </scm>
 
     <artifactId>ffm-plus</artifactId>
-    <version>0.2.2</version>
+    <version>0.2.3</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/modules/ffm-plus/src/main/java/club/doki7/ffm/annotation/Bitmask.java
+++ b/modules/ffm-plus/src/main/java/club/doki7/ffm/annotation/Bitmask.java
@@ -4,6 +4,6 @@ import java.lang.annotation.Documented;
 
 /// Marker annotation, indicating that an integral value is a C enumeration type.
 @Documented
-public @interface EnumType {
+public @interface Bitmask {
     Class<?> value() default Object.class;
 }

--- a/modules/ffm-plus/src/main/java/module-info.java
+++ b/modules/ffm-plus/src/main/java/module-info.java
@@ -11,7 +11,7 @@
 /// <dependency>
 ///     <groupId>club.doki7</groupId>
 ///     <artifactId>ffm-plus</artifactId>
-///     <version>0.2.2</version>
+///     <version>0.2.3</version>
 ///     <scope>compile</scope>
 /// </dependency>
 /// ```


### PR DESCRIPTION
Relevant with #105, affects https://github.com/club-doki7/ffm-plus-inspection.

CC @ice1000.