### PR TITLE
Use enums for singletons

### DIFF
--- a/modules/ffm-plus/src/main/java/club/doki7/ffm/LibcArena.java
+++ b/modules/ffm-plus/src/main/java/club/doki7/ffm/LibcArena.java
@@ -11,7 +11,9 @@ import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.util.Objects;
 
-public final class LibcArena implements Arena {
+public enum LibcArena implements Arena {
+    INSTANCE;
+
     private static final FunctionDescriptor DESCRIPTOR$aligned_alloc = FunctionDescriptor.of(
             ValueLayout.ADDRESS,
             NativeLayout.C_SIZE_T,
@@ -30,8 +32,6 @@ public final class LibcArena implements Arena {
             Objects.requireNonNull(JavaSystemLibrary.INSTANCE.load("free")),
             DESCRIPTOR$free
     );
-
-    private LibcArena() {}
 
     public void free(@NotNull MemorySegment ms) {
         try {
@@ -86,6 +86,4 @@ public final class LibcArena implements Arena {
     public void close() {
         throw new UnsupportedOperationException("Cannot close CArena");
     }
-
-    public static final LibcArena INSTANCE = new LibcArena();
 }

--- a/modules/ffm-plus/src/main/java/club/doki7/ffm/library/JavaSystemLibrary.java
+++ b/modules/ffm-plus/src/main/java/club/doki7/ffm/library/JavaSystemLibrary.java
@@ -6,7 +6,9 @@ import java.lang.foreign.Linker;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.SymbolLookup;
 
-public final class JavaSystemLibrary implements ISharedLibrary {
+public enum JavaSystemLibrary implements ISharedLibrary {
+    INSTANCE;
+
     @Override
     public @NotNull MemorySegment apply(@NotNull String name) {
         return loaderLookup.find(name)
@@ -16,10 +18,6 @@ public final class JavaSystemLibrary implements ISharedLibrary {
 
     @Override
     public void close() {}
-
-    private JavaSystemLibrary() {}
-
-    public static final JavaSystemLibrary INSTANCE = new JavaSystemLibrary();
 
     private static final Linker nativeLinker = Linker.nativeLinker();
     private static final SymbolLookup stdlibLookup = nativeLinker.defaultLookup();

--- a/modules/ffm-plus/src/main/java/club/doki7/ffm/library/JavaSystemLibraryLoader.java
+++ b/modules/ffm-plus/src/main/java/club/doki7/ffm/library/JavaSystemLibraryLoader.java
@@ -2,7 +2,9 @@ package club.doki7.ffm.library;
 
 import org.jetbrains.annotations.NotNull;
 
-public final class JavaSystemLibraryLoader implements ILibraryLoader {
+public enum JavaSystemLibraryLoader implements ILibraryLoader {
+    INSTANCE;
+
     @Override
     public @NotNull ISharedLibrary loadLibrary(@NotNull String libName) throws UnsatisfiedLinkError {
         try {
@@ -12,8 +14,4 @@ public final class JavaSystemLibraryLoader implements ILibraryLoader {
         }
         return JavaSystemLibrary.INSTANCE;
     }
-
-    public static final JavaSystemLibraryLoader INSTANCE = new JavaSystemLibraryLoader();
-
-    private JavaSystemLibraryLoader() {}
 }

--- a/modules/ffm-plus/src/main/java/club/doki7/ffm/library/UnixLibraryLoader.java
+++ b/modules/ffm-plus/src/main/java/club/doki7/ffm/library/UnixLibraryLoader.java
@@ -12,7 +12,9 @@ import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.util.Objects;
 
-public final class UnixLibraryLoader implements ILibraryLoader {
+public enum UnixLibraryLoader implements ILibraryLoader {
+    INSTANCE;
+
     @Override
     public @NotNull ISharedLibrary loadLibrary(@NotNull String libName) throws UnsatisfiedLinkError {
         if (!libName.startsWith("/")) {
@@ -39,10 +41,6 @@ public final class UnixLibraryLoader implements ILibraryLoader {
 
         return new UnixLibrary(result);
     }
-
-    public static final UnixLibraryLoader INSTANCE = new UnixLibraryLoader();
-
-    private UnixLibraryLoader() {}
 
     private static final FunctionDescriptor DESCRIPTOR$dlopen = FunctionDescriptor.of(
             ValueLayout.ADDRESS, // returns void*

--- a/modules/ffm-plus/src/main/java/club/doki7/ffm/library/WindowsLibraryLoader.java
+++ b/modules/ffm-plus/src/main/java/club/doki7/ffm/library/WindowsLibraryLoader.java
@@ -12,7 +12,9 @@ import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.util.Objects;
 
-public final class WindowsLibraryLoader implements ILibraryLoader {
+public enum WindowsLibraryLoader implements ILibraryLoader {
+    INSTANCE;
+
     @Override
     public @NotNull ISharedLibrary loadLibrary(@NotNull String libName) throws UnsatisfiedLinkError {
         MemorySegment result;
@@ -38,10 +40,6 @@ public final class WindowsLibraryLoader implements ILibraryLoader {
 
         return new WindowsLibrary(result);
     }
-
-    public static final WindowsLibraryLoader INSTANCE = new WindowsLibraryLoader();
-
-    private WindowsLibraryLoader() {}
 
     private static final FunctionDescriptor DESCRIPTOR$LoadLibraryW = FunctionDescriptor.of(
             ValueLayout.ADDRESS, // returns HMODULE


### PR DESCRIPTION
This is a non-breaking change, but adds the convenience that these classes are trivially serializable and the class loading order is less likely to be messed up if you do something crazy